### PR TITLE
Remove the first empty array element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default function loader(source) {
     }
   };
 
-  const result = `module.exports = [,${source
+  const result = `module.exports = [${source
     // split the source into 'lines' delimited by newline
     .split("\n")
     // if the last line is empty we discard it


### PR DESCRIPTION
Because of the comma at the beginning of the array, an empty array element gets created. It's skipped on the most kinds of iterations, like, `.filter()`, but is included in others, like `.find()`.
For instance this code breaks with `TypeError: Cannot destructure property 'id' of 'undefined' as it is undefined.`:
```
import list from "list.jsonl";
list.filter(({ id }) => id === 1)
```
